### PR TITLE
docker

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -367,3 +367,12 @@ FodyWeavers.xsd
 
 # Docker data
 /data
+
+# Extra
+.dockerignore
+.gitattributes
+.gitignore
+Dockerfile
+docker-compose.yml
+LICENSE.txt
+README.md

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
+WORKDIR /source
+
+COPY *.csproj .
+RUN dotnet restore
+
+COPY Astra.sln Astra.sln
+COPY src src
+RUN dotnet publish --no-restore -o /app
+
+FROM mcr.microsoft.com/dotnet/runtime:8.0
+WORKDIR /app
+COPY --from=build /app .
+ENTRYPOINT ["./Astra"]

--- a/README.md
+++ b/README.md
@@ -1,1 +1,7 @@
 # Astra
+
+## Run via docker
+
+```bash
+docker compose up -d
+```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,30 @@
+services:
+  astra:
+    container_name: astra
+    build: .
+    tty: true
+    stop_signal: SIGINT
+    deploy:
+      resources:
+        limits:
+          cpus: '2'
+          memory: 500MB
+      restart_policy:
+        condition: unless-stopped
+        delay: 30s
+        window: 300s
+    env_file:
+      - .env
+    environment:
+      Database__Host: db
+      Database__Port: 27017
+  db:
+    image: mongo:4
+    restart: always
+    deploy:
+      resources:
+        limits:
+          cpus: '2'
+          memory: 500MB
+    volumes:
+      - ./data/db:/data/db


### PR DESCRIPTION
for now, `.dockerignore` is just what was previously in `.gitignore` plus some other stuff;
both ignore files likely require cleanup to be more project-specific;
also expects a `.env` file:
```env
Discord__Token=stuffstuffstuff
```
