### PR TITLE
non-wildcard .csproj copy in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
 WORKDIR /source
 
-COPY *.csproj .
+COPY Astra.csproj .
 RUN dotnet restore
 
 COPY Astra.sln Astra.sln


### PR DESCRIPTION
Addresses the change in how build context handles `*.csproj` (which would fail on `./data` permission error)
